### PR TITLE
Sync with HF leaderboard: add Merged and Flagged fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+open-llm-leaderboard.*
+.DS_Store

--- a/openllm.py
+++ b/openllm.py
@@ -25,7 +25,7 @@ def get_datas(data):
                     type_of_emoji = data['components'][component_index]['props']['value']['data'][i][0]
 
                     try:
-                        results_json = {"T": type_of_emoji, "Model": results[-1], "Average ⬆️": results[2], "ARC": results[3], "HellaSwag": results[4], "MMLU": results[5], "TruthfulQA": results[6], "Winogrande": results[7], "GSM8K": results[8], "Type": results[9], "Architecture": results[10], "Precision": results[11], "Hub License": results[12], "#Params (B)": results[13], "Hub ❤️": results[14], "Available on the Hub": results[15], "Model Sha": results[16]}
+                        results_json = {"T": type_of_emoji, "Model": results[-1], "Average ⬆️": results[2], "ARC": results[3], "HellaSwag": results[4], "MMLU": results[5], "TruthfulQA": results[6], "Winogrande": results[7], "GSM8K": results[8], "Type": results[9], "Architecture": results[10], "Precision": results[11], "Merged": results[12], "Hub License": results[13], "#Params (B)": results[14], "Hub ❤️": results[15], "Available on the Hub": results[16], "Model Sha": results[17], "Flagged": results[18]}
                     except IndexError:  # Wrong component index, so breaking loop to try next component index. (NOTE: More than one component index can give you some results but we must find the right component index to get all results we want.)
                         break
                     result_list.append(results_json)


### PR DESCRIPTION
I added two new fields based on the latest change on HF leaderboard:
- Merged
- Flagged

Additionally, I also add a .gitignore file for cache/output files.
I hope you're okay with this change.